### PR TITLE
remove www from twitter links (not needed)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,8 +1658,8 @@
 				<p>HTML5 Accessiblity was <a href="http://www.paciellogroup.com">developed by The Paciello Group</a>, your accessibility partner.
 				<a href="http://www.paciellogroup.com/contact/">Contact us</a> for solutions to your accessibility issues.</p>
 					
-				<p>Further design and development by <a href="https://www.twitter.com/dstorey">David Storey</a> and 
-				<a href="https://www.twitter.com/somelaniesaid">Melanie Richards</a>.</p>
+				<p>Further design and development by <a href="https://twitter.com/dstorey">David Storey</a> and 
+				<a href="https://twitter.com/somelaniesaid">Melanie Richards</a>.</p>
 			</section>
 		</section>
 	</main>


### PR DESCRIPTION
remove www from twitter links (not needed). saves a http redirect.