### PR TITLE
Track mapping removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
 							<td class="no">no</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>track</code></a></th>
+							<th scope="row" rowspan="3"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>track</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -621,14 +621,6 @@
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
-							<td class="yes">yes</td>
-							<td class="yes">yes</td>
-							<td class="yes">yes</td>
-							<td class="yes">yes</td>
-							<td class="yes">yes</td>
-						</tr>
-						<tr>
-							<td>Mapped</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>


### PR DESCRIPTION
Reason:

In all A11y APIs, track is not mapped, so it is not testing anything.
https://w3c.github.io/aria/html-aam/html-aam.html#el-track