### PR TITLE
Add fail links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1162,11 +1162,11 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=27247">no</a></td>
 						</tr>
 						<tr>
 							<td>Mapped</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=282005">no</a></td>
 							<td>&nbsp;</td>
 							<td class="yes">yes</td>
 							<td>&nbsp;</td>

--- a/index.html
+++ b/index.html
@@ -1192,9 +1192,9 @@
 						<tr>
 							<td>Feature implemented</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/outputelement">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/outputelement">no</a></td>
 							<td class="no">no</td>
 						</tr>
 						<tr>

--- a/index.html
+++ b/index.html
@@ -1464,9 +1464,9 @@
 						<tr>
 							<td>Feature implemented</td>
 							<td class="yes">yes</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/dialogelementformodals/">no</a></td>
 							<td class="no">no</td>
-							<td class="no">no</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/dialogelementformodals/">no</a></td>
 							<td class="no">no</td>
 						</tr>
 						<tr>

--- a/index.html
+++ b/index.html
@@ -321,7 +321,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=108996">no</a></td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>

--- a/index.html
+++ b/index.html
@@ -1267,7 +1267,7 @@
 							<td>Mapped</td>
 							<td class="partial">partial</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="partial"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=559770">partial</a></td>
 							<td class="n-a">n/a</td>
 							<td class="yes">yes</td>
 						</tr>

--- a/index.html
+++ b/index.html
@@ -469,11 +469,11 @@
 						</tr>
 						<tr>
 							<td>Mapped</td>
-							<td>&nbsp;</td>
-							<td class="no">no</td>
-							<td>&nbsp;</td>
-							<td class="no">no</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=494612">no</a></td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7350313/">no</a></td>
+							<td class="no"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=982125">no</a></td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7350313/">no</a></td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=109018">no</a></td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>

--- a/index.html
+++ b/index.html
@@ -523,9 +523,9 @@
 						<tr>
 							<td>drawFocusIfNeeded()</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/canvasfocusring">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/canvasfocusring?">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>

--- a/index.html
+++ b/index.html
@@ -1118,16 +1118,16 @@
 						<tr>
 							<td>Feature implemented</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/">no</a></td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=61276">no</a></td>
 						</tr>
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
 							<td class="n-a">n/a</td>
-							<td class="partial">partial</td>
+							<td class="partial"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=559767">partial</a></td>
 							<td class="n-a">n/a</td>
 							<td class="n-a">n/a</td>
 						</tr>

--- a/index.html
+++ b/index.html
@@ -1260,7 +1260,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/meterelement/"no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -1291,9 +1291,9 @@
 						<tr>
 							<td>Feature implemented</td>
 							<td class="yes">yes</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/">no</a></td>
 							<td class="no">no</td>
-							<td class="no">no</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -1302,7 +1302,7 @@
 							<td class="n-a">n/a</td>
 							<td class="n-a">n/a</td>
 							<td class="n-a">n/a</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=131111">no</a></td>
 						</tr>
 						<tr>
 							<td>Keyboard</td>
@@ -1324,9 +1324,9 @@
 						<tr>
 							<td>Feature implemented</td>
 							<td class="yes">yes</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/">no</a></td>
 							<td class="no">no</td>
-							<td class="no">no</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -1335,7 +1335,7 @@
 							<td class="n-a">n/a</td>
 							<td class="n-a">n/a</td>
 							<td class="n-a">n/a</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=131111">no</a></td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>

--- a/index.html
+++ b/index.html
@@ -683,9 +683,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -716,9 +716,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="no">no</td>
 						</tr>
 						<tr>
@@ -749,9 +749,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="no">no</td>
 						</tr>
 						<tr>
@@ -790,9 +790,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="no">no</td>
 						</tr>
 						<tr>
@@ -1036,9 +1036,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>

--- a/index.html
+++ b/index.html
@@ -120,9 +120,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -153,9 +153,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -186,9 +186,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -219,9 +219,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -252,9 +252,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -285,9 +285,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -320,7 +320,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="no">no</td>
 						</tr>
 						<tr>
@@ -351,9 +351,9 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
@@ -384,7 +384,7 @@
 						<tr>
 							<td>Mapped</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://connect.microsoft.com/IE/feedback/details/804723/html5-structural-elements-not-exposed-via-accessibility-api">no</a></td>
 							<td class="yes">yes</td>
 							<td class="n-a">n/a</td>
 							<td class="yes">yes</td>

--- a/index.html
+++ b/index.html
@@ -719,7 +719,7 @@
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=145973">no</a></td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>
@@ -752,7 +752,7 @@
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=145973">no</a></td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>
@@ -793,7 +793,7 @@
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=145973">no</a></td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>

--- a/index.html
+++ b/index.html
@@ -575,7 +575,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=157736">no</a></td>
 						</tr>
 						<tr>
 							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>video</code></a></th>
@@ -606,9 +606,9 @@
 							<td>Keyboard</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=494175">no</a></td>
 							<td class="yes">yes</td>
-							<td class="no">no</td>
+							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=157736">no</a></td>
 						</tr>
 						<tr>
 							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>track</code></a></th>

--- a/style/styles.css
+++ b/style/styles.css
@@ -811,7 +811,7 @@ table {
 
 
 /* only controls as others are not very long. Consider for elements */
-#controls thead {
+[aria-labelledby="controls"] thead {
 	position: -webkit-sticky;
 	position: sticky;
 	top: 0;

--- a/style/styles.css
+++ b/style/styles.css
@@ -936,6 +936,7 @@ td.yes,
 td.no,
 td.n-a,
 td.partial {
+	position: relative;
 	max-width: 60px;
 	overflow: hidden;
 	text-indent: 110%;
@@ -948,6 +949,20 @@ td.partial {
 
 .no {
 	background-image: url(../images/status-icons/no.svg);
+}
+
+td.no a {
+	position: absolute;
+	top: 4px;
+	bottom: 3px;
+	left: 6px;
+	right: 4px;
+	
+	border: 0;
+}
+
+.no a:focus {
+	outline: 1px dotted #000;
 }
 
 .n-a {

--- a/style/styles.css
+++ b/style/styles.css
@@ -951,7 +951,8 @@ td.partial {
 	background-image: url(../images/status-icons/no.svg);
 }
 
-td.no a {
+td.no a,
+td.partial a {
 	position: absolute;
 	top: 4px;
 	bottom: 3px;
@@ -961,7 +962,8 @@ td.no a {
 	border: 0;
 }
 
-.no a:focus {
+.no a:focus,
+.partial a:focus {
 	outline: 1px dotted #000;
 }
 

--- a/style/styles.css
+++ b/style/styles.css
@@ -967,6 +967,11 @@ td.partial a {
 	outline: 1px dotted #000;
 }
 
+.no a:active,
+.partial a:active {
+	background: 0;
+}
+
 .n-a {
 	background-image:  url(../images/status-icons/n-a.svg);
 }


### PR DESCRIPTION
Add links for most cases where there is comments in current tests about failures.

Some links are not currently there, for either missing features (added some but not all), and places where there is text but no bug filed (or at least linked to). I filed a couple that I know still reproduce but need to file rest when testing the browsers with new criteria.