### PR TITLE
Fix expand/collapse buttons in iOS/Safari

### DIFF
--- a/style/styles.css
+++ b/style/styles.css
@@ -926,7 +926,7 @@ th button {
 
 	background: url("../images/ui-icons/toggle-open.svg") no-repeat center transparent;
 
-	text-indent: 200%;
+	text-indent: 22px;
 	overflow: hidden;
 
 	line-height: 1.4;


### PR DESCRIPTION
Fixes issue where the "expand"/"collapse" button text still appears, not indented out of sight, on the +/- expando buttons in iOS/Safari.