### PR TITLE
Fix a typo in #contributors subsection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1641,7 +1641,7 @@
 			<section id="contributors" class="meta">
 				<h3>Contributors</h3>
 
-				<p>HTML5 Accessiblity was <a href="http://www.paciellogroup.com">developed by The Paciello Group</a>, your accessibility partner.
+				<p>HTML5 Accessibility was <a href="http://www.paciellogroup.com">developed by The Paciello Group</a>, your accessibility partner.
 				<a href="http://www.paciellogroup.com/contact/">Contact us</a> for solutions to your accessibility issues.</p>
 
 				<p>Further design and development by <a href="https://twitter.com/dstorey">David Storey</a> and


### PR DESCRIPTION
“HTML5 Accessiblity was […]” should read “HTML5 Accessibility was […]” :stuck_out_tongue:

https://github.com/stevefaulkner/HTML5accessibility/blob/6bbbf75bbca68d12a13a81d0856faa66b0c05d9d/index.html#L1641-L1649