### PR TITLE
Patch links

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
 				<aside class="sponsor">
 					<img src="images/logos/nvda.svg" alt="" />
-					<p><a href="http://www.nvaccess.org/wiki/Donate">Donate to
+					<p><a href="https://www.nvaccess.org/wiki/Donate">Donate to
 						<abbr title="NonVisual Desktop Access ">NVDA</abbr></a>,
 						the open source screen reader for Windows.
 					</p>
@@ -101,7 +101,7 @@
 					</thead>
 					<tbody>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/article.html">article</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/article.html">article</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -134,7 +134,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/section.html">section</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/section.html">section</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -167,7 +167,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/nav.html">nav</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/nav.html">nav</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -200,7 +200,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/aside.html">aside</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/aside.html">aside</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -233,7 +233,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/header.html">header</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/header.html">header</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -266,7 +266,7 @@
 							<td class="yes">Yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/footer.html">footer</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/footer.html">footer</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -299,7 +299,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/figure.html">figure</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/figure.html">figure</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -332,7 +332,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="3"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/figure-figcaption.html">figcaption</a></code></th>
+							<th scope="row" rowspan="3"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/figure-figcaption.html">figcaption</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -357,7 +357,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/main.html"><code>main</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/main.html"><code>main</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -410,7 +410,7 @@
 					</thead>
 					<tbody>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/time.html"><code>time</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/time.html"><code>time</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -443,7 +443,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/mark.html"><code>mark</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/mark.html"><code>mark</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -496,7 +496,7 @@
 					</thead>
 					<tbody>
 						<tr>
-							<th scope="row" rowspan="5"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/canvas.html">canvas</a></code></th>
+							<th scope="row" rowspan="5"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/canvas.html">canvas</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -537,7 +537,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/audio.html"><code>audio</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/audio.html"><code>audio</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -570,7 +570,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>video</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>video</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -603,7 +603,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="3"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>track</code></a></th>
+							<th scope="row" rowspan="3"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/video.html"><code>track</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -648,7 +648,7 @@
 					</thead>
 					<tbody>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-search.html"><code>search</code></a> input</th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-search.html"><code>search</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -681,7 +681,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-tel.html"><code>tel</code></a> input</th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-tel.html"><code>tel</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -714,7 +714,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-url.html"><code>url</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-url.html"><code>url</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -755,7 +755,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-email.html"><code>email</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-email.html"><code>email</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -796,7 +796,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-datetime-local.html"><code>datetime-&#8203;local</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-datetime-local.html"><code>datetime-&#8203;local</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -837,7 +837,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-date.html"><code>date</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-date.html"><code>date</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -878,7 +878,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-month.html"><code>month</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-month.html"><code>month</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -919,7 +919,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-week.html"><code>week</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-week.html"><code>week</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -960,7 +960,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-time.html"><code>time</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-time.html"><code>time</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -1001,7 +1001,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="6"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-number.html"><code>number</code></a> input</th>
+							<th scope="row" rowspan="6"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-number.html"><code>number</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -1050,7 +1050,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-range.html"><code>range</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-range.html"><code>range</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -1091,7 +1091,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/input-color.html"><code>color</code></a> input</th>
+							<th scope="row" rowspan="5"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/input-color.html"><code>color</code></a> input</th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -1132,7 +1132,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/datalist.html">datalist</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/datalist.html">datalist</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -1165,7 +1165,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/output.html">output</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/output.html">output</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -1198,7 +1198,7 @@
 							<td class="partial">partial</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/progress.html">progress</a></code></th>
+							<th scope="row" rowspan="4"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/progress.html">progress</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -1231,7 +1231,7 @@
 							<td class="partial">partial</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/meter.html"><code>meter</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/meter.html"><code>meter</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -1264,7 +1264,7 @@
 							<td class="partial">partial</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/details-summary.html"><code>details</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/details-summary.html"><code>details</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="n-a">not implemented</td>
@@ -1297,7 +1297,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="5"><code><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/details-summary.html">summary</a></code></th>
+							<th scope="row" rowspan="5"><code><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/details-summary.html">summary</a></code></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="n-a">not implemented</td>
@@ -1338,7 +1338,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/menu-toolbar.html"><code>toolbar</code></a> menu</th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/menu-toolbar.html"><code>toolbar</code></a> menu</th>
 							<td>Accessibly supported</td>
 							<td class="n-a">not implemented</td>
 							<td class="n-a">not implemented</td>
@@ -1371,7 +1371,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/menu-context.html"><code>context</code></a> menu</th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/menu-context.html"><code>context</code></a> menu</th>
 							<td>Accessibly supported</td>
 							<td class="n-a">not implemented</td>
 							<td class="n-a">not implemented</td>
@@ -1404,7 +1404,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/menuitem.html"><code>menuitem</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/menuitem.html"><code>menuitem</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="n-a">not implemented</td>
 							<td class="n-a">not implemented</td>
@@ -1437,7 +1437,7 @@
 							<td class="n-a">n/a</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://codepen.io/stevef/debug/dPxgZq"><code>dialog</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://codepen.io/stevef/debug/dPxgZq"><code>dialog</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="n-a">not implemented</td>
@@ -1499,7 +1499,7 @@
 							<td>&nbsp;</td>
 						</tr>-->
 						<tr>
-							<th scope="row" rowspan="3"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/hidden-att.html"><code>hidden</code></a></th>
+							<th scope="row" rowspan="3"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/hidden-att.html"><code>hidden</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -1524,7 +1524,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/required-att.html"><code>required</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/required-att.html"><code>required</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
@@ -1557,7 +1557,7 @@
 							<td class="yes">yes</td>
 						</tr>
 						<tr>
-							<th scope="row" rowspan="4"><a href="http://thepaciellogroup.github.io/AT-browser-tests/test-files/placeholder-att.html"><code>placeholder</code></a></th>
+							<th scope="row" rowspan="4"><a href="https://thepaciellogroup.github.io/AT-browser-tests/test-files/placeholder-att.html"><code>placeholder</code></a></th>
 							<td>Accessibly supported</td>
 							<td class="partial">partial</td>
 							<td class="yes">yes</td>
@@ -1618,7 +1618,7 @@
 
 				<ul>
 					<li><a href="https://www.paciellogroup.com/resources/aviewer/">Aviewer</a> (Windows)</li>
-					<li><a href="http://msdn.microsoft.com/en-us/library/dd318521%28v=vs.85%29.aspx">Inspect</a> (Windows SDK)</li>
+					<li><a href="https://msdn.microsoft.com/en-us/library/dd318521%28v=vs.85%29.aspx">Inspect</a> (Windows SDK)</li>
 					<li><a href="http://accessibility.linuxfoundation.org/a11yweb/util/accprobe/">Accprobe</a> (Windows)</li>
 					<li><a href="https://developer.apple.com/library/mac/documentation/Accessibility/Conceptual/AccessibilityMacOSX/OSXAXTestingApps.html">Accessibility Inspector</a> (Xcode, OS&nbsp;X)</li>
 				</ul>
@@ -1633,7 +1633,7 @@
 
 				<ul>
 					<li><a href="http://www.html5accessibility.com/html5elements/">HTML5 Elements test page</a></li>
-					<li><a href="http://thepaciellogroup.github.io/AT-browser-tests/">Aural UI of HTML</a></li>
+					<li><a href="https://thepaciellogroup.github.io/AT-browser-tests/">Aural UI of HTML</a></li>
 					<li><a href="http://w3c.github.io/aria-in-html/">Using ARIA</a></li>
 				</ul>
 			</section>
@@ -1641,8 +1641,8 @@
 			<section id="contributors" class="meta">
 				<h3>Contributors</h3>
 
-				<p>HTML5 Accessibility was <a href="http://www.paciellogroup.com">developed by The Paciello Group</a>, your accessibility partner.
-				<a href="http://www.paciellogroup.com/contact/">Contact us</a> for solutions to your accessibility issues.</p>
+				<p>HTML5 Accessibility was <a href="https://www.paciellogroup.com">developed by The Paciello Group</a>, your accessibility partner.
+				<a href="https://www.paciellogroup.com/contact/">Contact us</a> for solutions to your accessibility issues.</p>
 
 				<p>Further design and development by <a href="https://twitter.com/dstorey">David Storey</a> and
 				<a href="https://twitter.com/somelaniesaid">Melanie Richards</a>.</p>
@@ -1652,7 +1652,7 @@
 
 	<footer>
 		<small class="licence">
-			This work is licenced under a <a href="http://creativecommons.org/licenses/by-sa/2.0/uk/" rel="license">Creative Commons Licence.</a>
+			This work is licenced under a <a href="https://creativecommons.org/licenses/by-sa/2.0/uk/" rel="license">Creative Commons Licence.</a>
 		</small>
 
 		<a class="github" href="https://github.com/stevefaulkner/HTML5accessibility">Fork on GitHub</a>

--- a/index.html
+++ b/index.html
@@ -1634,7 +1634,7 @@
 				<ul>
 					<li><a href="http://www.html5accessibility.com/html5elements/">HTML5 Elements test page</a></li>
 					<li><a href="https://thepaciellogroup.github.io/AT-browser-tests/">Aural UI of HTML</a></li>
-					<li><a href="http://w3c.github.io/aria-in-html/">Using ARIA</a></li>
+					<li><a href="https://w3c.github.io/using-aria/">Using ARIA</a></li>
 				</ul>
 			</section>
 


### PR DESCRIPTION
Links URLs are now set to `https` whenever possible.

"Using ARIA" resource was moved to another location. Corresponding link was updated accordingly.