### PR TITLE
updating Safari results for placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
@@ -1587,7 +1587,7 @@
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 					</tbody>
 				</table>


### PR DESCRIPTION
Because placeholder is not in the Name Computation, TEST PH-004 is wrong, and Safari results (title attr wins) are correct.