### PR TITLE
Updated Safari score for 11.0.3.

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,9 @@
 					<p class="result">56%</p>
 				</li>
 				<li class="safari high">
-					<h3 class="browser">Safari 11.0.2</h3>
+					<h3 class="browser">Safari 11.0.3</h3>
 					<p class="platform">on OS High Sierra</p>
-					<p class="result">90%</p>
+					<p class="result">98%</p>
 				</li>
 			</ul>
 		</section>
@@ -687,7 +687,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
@@ -703,7 +703,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
-							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=145973">no</a></td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>
@@ -720,7 +720,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
@@ -736,7 +736,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
-							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=145973">no</a></td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>
@@ -761,7 +761,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
@@ -777,7 +777,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="no"><a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7568782/">no</a></td>
-							<td class="no"><a href="https://bugs.webkit.org/show_bug.cgi?id=145973">no</a></td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Name/Description</td>
@@ -1007,7 +1007,7 @@
 							<td class="yes">yes</td>
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
@@ -1039,7 +1039,7 @@
 							<td class="yes">yes</td>
 							<td>&nbsp;</td>
 							<td class="no">no</td>
-							<td class="no">no</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Keyboard</td>
@@ -1563,7 +1563,7 @@
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 						<tr>
 							<td>Feature implemented</td>
@@ -1587,7 +1587,7 @@
 							<td class="yes">yes</td>
 							<td class="partial">partial</td>
 							<td class="partial">partial</td>
-							<td class="partial">partial</td>
+							<td class="yes">yes</td>
 						</tr>
 					</tbody>
 				</table>


### PR DESCRIPTION
Including `input` type description (this bug targets `email`, `tel`, `url`, `date`, `time`)
https://bugs.webkit.org/show_bug.cgi?id=163419

Exposing validation staus
https://bugs.webkit.org/show_bug.cgi?id=163252

Exposing `placeholder` value
https://bugs.webkit.org/show_bug.cgi?id=163229

Score:
∵ There is 1  partially supported feature (meter), and 10 unimplemented features out of 40.
∴ Score = 100 - (1 * 0.5 * 100 / (40 - 10))