### PR TITLE
Add month/year of testing to results

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,27 +30,27 @@
 			<ul class="test-results">
 				<li class="chrome high">
 					<h3 class="browser">Chrome 62</h3>
-					<p class="platform">on Windows 10</p>
+					<p class="platform">Tested Dec. 2017<br>on Windows 10</p>
 					<p class="result">92%</p>
 				</li>
 				<li class="edge high">
 					<h3 class="browser">Edge 80</h3>
-					<p class="platform">on Windows 10</p>
+					<p class="platform">Tested Apr. 2020<br>on Windows 10</p>
 					<p class="result">100%</p>
 				</li>
 				<li class="firefox high">
 					<h3 class="browser">Firefox 58.0b9</h3>
-					<p class="platform">on Windows 10</p>
+					<p class="platform">Tested Dec. 2017<br>on Windows 10</p>
 					<p class="result">89%</p>
 				</li>
 				<li class="ie low">
 					<h3 class="browser">Internet Explorer 11</h3>
-					<p class="platform">on Windows 10</p>
+					<p class="platform">Tested Dec. 2017<br>on Windows 10</p>
 					<p class="result">56%</p>
 				</li>
 				<li class="safari high">
 					<h3 class="browser">Safari 11.0.3</h3>
-					<p class="platform">on OS High Sierra</p>
+					<p class="platform">Tested Feb. 2018<br>on OS High Sierra</p>
 					<p class="result">98%</p>
 				</li>
 			</ul>

--- a/style/styles.css
+++ b/style/styles.css
@@ -428,6 +428,10 @@ nav a {
 	line-height: 1.5;
 }
 
+.platform {
+	margin-top: 4px;
+}
+
 .result {
 	display: inline-block;
 
@@ -494,7 +498,7 @@ nav a {
 	.test-results li {
 		float: left;
 		width: calc(50% - 6px);
-		height: 308px;
+		height: 332px;
 		margin: 0 0 12px 0;
 		padding-top: 122px;
 


### PR DESCRIPTION
Given that the browsers aren't tested all together, it's important to make it clear when each test was done so that readers can have an idea of how up-to-date each result is. This PR adds that information.

The dates are taken from the commit history, more specifically:
- Safari: fe2149e4
- Edge: cf4e158d
- Others: 7770466d

For visual reference, the update looks like this:

![Screenshot of results](https://user-images.githubusercontent.com/4542461/79036544-5f8de880-7bc9-11ea-828c-f47211c6a624.png)

